### PR TITLE
allow the library to work even if revisions are not enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -55,13 +55,9 @@ module.exports = function (pth, opts) {
 
 	return through.obj(function (file, enc, cb) {
 		// ignore all non-rev'd files
-		if (!file.path || !file.revOrigPath) {
-			cb();
-			return;
-		}
-
+		var revisionsEnabled = file.path && file.revOrigPath;
 		var revisionedFile = relPath(file.base, file.path);
-		var originalFile = path.join(path.dirname(revisionedFile), path.basename(file.revOrigPath)).replace(/\\/g, '/');
+		var originalFile = revisionsEnabled ? path.join(path.dirname(revisionedFile), path.basename(file.revOrigPath)).replace(/\\/g, '/') : revisionedFile;;
 
 		manifest[originalFile] = revisionedFile;
 
@@ -89,7 +85,7 @@ module.exports = function (pth, opts) {
 				manifest = assign(oldManifest, manifest);
 			}
 
-			manifestFile.contents = new Buffer(opts.transformer.stringify(sortKeys(manifest), null, '  '));
+			manifestFile.contents = Buffer.from(opts.transformer.stringify(sortKeys(manifest), null, '  '));
 			this.push(manifestFile);
 			cb();
 		}.bind(this));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-revmanifest",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Generate a rev-manifest file, mapping original paths to revisioned counterparts.",
   "license": "MIT",
   "repository": "lukeed/gulp-rev-manifest",

--- a/test.js
+++ b/test.js
@@ -18,7 +18,7 @@ it('should build a rev manifest file', function (cb) {
 
 	var file = new gutil.File({
 		path: 'unicorn-d41d8cd98f.css',
-		contents: new Buffer('')
+		contents: Buffer.from('')
 	});
 
 	file.revOrigPath = 'unicorn.css';
@@ -38,7 +38,7 @@ it('should allow naming the manifest file', function (cb) {
 
 	var file = new gutil.File({
 		path: 'unicorn-d41d8cd98f.css',
-		contents: new Buffer('')
+		contents: Buffer.from('')
 	});
 
 	file.revOrigPath = 'unicorn.css';
@@ -67,7 +67,7 @@ it('should append to an existing rev manifest file', function (cb) {
 
 	var file = new gutil.File({
 		path: 'unicorn-d41d8cd98f.css',
-		contents: new Buffer('')
+		contents: Buffer.from('')
 	});
 
 	file.revOrigPath = 'unicorn.css';
@@ -90,7 +90,7 @@ it('should not append to an existing rev manifest by default', function (cb) {
 
 	var file = new gutil.File({
 		path: 'unicorn-d41d8cd98f.css',
-		contents: new Buffer('')
+		contents: Buffer.from('')
 	});
 
 	file.revOrigPath = 'unicorn.css';
@@ -115,14 +115,14 @@ it('should sort the rev manifest keys', function (cb) {
 
 	var file = new gutil.File({
 		path: 'unicorn-d41d8cd98f.css',
-		contents: new Buffer('')
+		contents: Buffer.from('')
 	});
 
 	file.revOrigPath = 'unicorn.css';
 
 	var fileTwo = new gutil.File({
 		path: 'pony-d41d8cd98f.css',
-		contents: new Buffer('')
+		contents: Buffer.from('')
 	});
 
 	fileTwo.revOrigPath = 'pony.css';
@@ -149,7 +149,7 @@ it('should respect directories', function (cb) {
 		cwd: __dirname,
 		base: __dirname,
 		path: path.join(__dirname, 'foo', 'unicorn-d41d8cd98f.css'),
-		contents: new Buffer('')
+		contents: Buffer.from('')
 	});
 
 	file1.revOrigBase = __dirname;
@@ -161,7 +161,7 @@ it('should respect directories', function (cb) {
 		cwd: __dirname,
 		base: __dirname,
 		path: path.join(__dirname, 'bar', 'pony-d41d8cd98f.css'),
-		contents: new Buffer('')
+		contents: Buffer.from('')
 	});
 
 	file2.revOrigBase = __dirname;
@@ -191,7 +191,7 @@ it('should respect files coming from directories with different bases', function
 		cwd: __dirname,
 		base: path.join(__dirname, 'output'),
 		path: path.join(__dirname, 'output', 'foo', 'scriptfoo-d41d8cd98f.js'),
-		contents: new Buffer('')
+		contents: Buffer.from('')
 	});
 
 	file1.revOrigBase = path.join(__dirname, 'vendor1');
@@ -203,7 +203,7 @@ it('should respect files coming from directories with different bases', function
 		cwd: __dirname,
 		base: path.join(__dirname, 'output'),
 		path: path.join(__dirname, 'output', 'bar', 'scriptbar-d41d8cd98f.js'),
-		contents: new Buffer('')
+		contents: Buffer.from('')
 	});
 
 	file2.revOrigBase = path.join(__dirname, 'vendor2');
@@ -232,7 +232,7 @@ it('should use correct base path for each file', function (cb) {
 		cwd: 'app/',
 		base: 'app/',
 		path: path.join('app', 'foo', 'scriptfoo-d41d8cd98f.js'),
-		contents: new Buffer('')
+		contents: Buffer.from('')
 	});
 	fileFoo.revOrigPath = 'scriptfoo.js';
 
@@ -240,11 +240,32 @@ it('should use correct base path for each file', function (cb) {
 		cwd: 'assets/',
 		base: 'assets/',
 		path: path.join('assets', 'bar', 'scriptbar-d41d8cd98f.js'),
-		contents: new Buffer('')
+		contents: Buffer.from('')
 	});
 	fileBar.revOrigPath = 'scriptbar.js';
 
 	stream.write(fileFoo);
 	stream.write(fileBar);
+	stream.end();
+});
+
+it('should correctly work even if revisions are not enabled', function (cb) {
+	var stream = lib();
+
+	stream.on('data', function (newFile) {
+		assert.equal(newFile.relative, 'rev-manifest.json');
+		assert.deepEqual(
+			JSON.parse(newFile.contents.toString()),
+			{'unicorn.css': 'unicorn.css'}
+		);
+		cb();
+	});
+
+	var file = new gutil.File({
+		path: 'unicorn.css',
+		contents: Buffer.from('')
+	});
+
+	stream.write(file);
 	stream.end();
 });


### PR DESCRIPTION
in the previous version, no manifest would be generated... the new version fixes that behaviour and generates manifest.json with proper paths (even though key and values are equal)